### PR TITLE
Page Stub: Fix NyState → NyPage in page_w_controller_stub.dart

### DIFF
--- a/lib/metro/stubs/page_w_controller_stub.dart
+++ b/lib/metro/stubs/page_w_controller_stub.dart
@@ -14,7 +14,7 @@ class ${className.pascalCase}Page extends NyStatefulWidget<${className.pascalCas
   ${className.pascalCase}Page({super.key}) : super(child: () => _${className.pascalCase}PageState());
 }
 
-class _${className.pascalCase}PageState extends NyState<${className.pascalCase}Page> {
+class _${className.pascalCase}PageState extends NyPage<${className.pascalCase}Page> {
 
   /// [${className.pascalCase}Controller] controller
   ${className.pascalCase}Controller get controller => widget.controller;


### PR DESCRIPTION
Hey! 👋

While using Nylo 6.x, I ran into an issue where route guards were not working as expected. After some debugging, I found that pages generated with -c controller were extending NyState instead of NyPage, which prevents middleware from functioning properly.

I noticed that when Nylo migrated from 5.x to 6.x, the page_stub.dart file was correctly updated to replace NyState with NyPage, but page_w_controller_stub.dart was not updated. This inconsistency results in incorrect class generation when creating pages with controllers.

This PR updates page_w_controller_stub.dart to ensure that pages generated with controllers extend NyPage, aligning with the intended framework behavior.

Hope this helps! Let me know if any changes are needed. Thanks for the awesome framework! 🎉

🔗 GitHub Commit Reference:
[Migration commit from 5.x to 6.x](https://github.com/nylo-core/framework/commit/31f72cbdbd8087785fb005718b19827a62e27a61#diff-d3c4bae3de836e2a56c5d183d3dcdc66616ff55d3523bba02ab38598bed0dbb9R15)